### PR TITLE
Urls: Required parameter missing (kind).

### DIFF
--- a/src/Rede/Transaction.php
+++ b/src/Rede/Transaction.php
@@ -382,7 +382,7 @@ class Transaction implements RedeSerializable, RedeUnserializable
                 'additional' => $this->additional
             ],
             function ($value) {
-                return !is_null($value);
+                return !empty($value);
             }
         );
     }


### PR DESCRIPTION
jsonSerialize - array filter changed from !is_null to !empty.
Property urls always return with empty array is throws an error Urls: Required parameter missing (kind).

https://github.com/DevelopersRede/erede-php/pull/69
https://github.com/DevelopersRede/erede-php/issues/68